### PR TITLE
stop controller face buttons from scrolling when held down

### DIFF
--- a/scripts/modconfig.lua
+++ b/scripts/modconfig.lua
@@ -1722,7 +1722,7 @@ function ModConfigMenu.PostRender()
 
       end
 
-      if not InputHelper.MultipleButtonTriggered(ignoreActionButtons) then
+      if not InputHelper.MultipleButtonPressed(ignoreActionButtons) then
         --pressing buttons
         local downButtonPressed = InputHelper.MultipleActionTriggered(actionsDown)
         if downButtonPressed then


### PR DESCRIPTION
Right now, if you press A on the controller it'll toggle the currently selected value.

If you press and hold A, it starts scrolling down the list which seems like bad behavior since it's setup to be ignored for this purpose.