### PR TITLE
Feat: Implement CurrentFocus Getter

### DIFF
--- a/scripts/modconfig.lua
+++ b/scripts/modconfig.lua
@@ -2992,6 +2992,14 @@ if ModConfigMenu.StandaloneMod then
   end
 end
 
+function ModConfigMenu.GetCurrentFocus()
+  return {
+    category = currentMenuCategory,
+    subcategory = currentMenuSubcategory,
+    option = currentMenuOption
+  }
+end
+
 ------------
 --FINISHED--
 ------------


### PR DESCRIPTION
Simply return currentFocus Menu, Category and Options

<img width="1279" height="690" alt="image" src="https://github.com/user-attachments/assets/9e5985f1-44b0-49b4-af36-554c2de5c5c5" />

Add getter function to return current menu focus (currentMenuCategory, etc).
Works as intended, feel free to change return value names if needed.

![Focus](https://github.com/user-attachments/assets/dace1b2c-4fa1-4918-b067-ef9ae44f162e)

Simply render Items using this code for local environment